### PR TITLE
Add PS1 Multitap support, add Memory Card enable/disable options (Jokippo)

### DIFF
--- a/Gamecube/GamecubeMain.cpp
+++ b/Gamecube/GamecubeMain.cpp
@@ -125,8 +125,8 @@ char screenMode = 0;
 char videoMode = 0;
 char fileSortMode = 1;
 char padAutoAssign;
-char padType[2];
-char padAssign[2];
+char padType[10];
+char padAssign[10];
 char rumbleEnabled;
 char loadButtonSlot;
 char controllerType;
@@ -141,6 +141,7 @@ char trapFilter = 1;
 char interlacedMode = 0;
 char deflickerFilter = 1;
 char lightGun = 0;
+char memCard[2];
 
 #define CONFIG_STRING_TYPE 0
 #define CONFIG_STRING_SIZE 256
@@ -176,10 +177,26 @@ static struct {
   { "SkipFrames", &frameSkip, FRAMESKIP_DISABLE, FRAMESKIP_ENABLE },
   { "Dithering", &useDithering, USEDITHER_NONE, USEDITHER_ALWAYS },
   { "PadAutoAssign", &padAutoAssign, PADAUTOASSIGN_MANUAL, PADAUTOASSIGN_AUTOMATIC },
-  { "PadType1", &padType[0], PADTYPE_NONE, PADTYPE_WII },
-  { "PadType2", &padType[1], PADTYPE_NONE, PADTYPE_WII },
-  { "PadAssign1", &padAssign[0], PADASSIGN_INPUT0, PADASSIGN_INPUT3 },
-  { "PadAssign2", &padAssign[1], PADASSIGN_INPUT0, PADASSIGN_INPUT3 },
+  { "PadType1", &padType[0], PADTYPE_NONE, PADTYPE_MULTITAP },
+  { "PadType2", &padType[1], PADTYPE_NONE, PADTYPE_MULTITAP },
+  { "PadType3", &padType[2], PADTYPE_NONE, PADTYPE_MULTITAP },
+  { "PadType4", &padType[3], PADTYPE_NONE, PADTYPE_MULTITAP },
+  { "PadType5", &padType[4], PADTYPE_NONE, PADTYPE_MULTITAP },
+  { "PadType6", &padType[5], PADTYPE_NONE, PADTYPE_MULTITAP },
+  { "PadType7", &padType[6], PADTYPE_NONE, PADTYPE_MULTITAP },
+  { "PadType8", &padType[7], PADTYPE_NONE, PADTYPE_MULTITAP },
+  { "PadType9", &padType[8], PADTYPE_NONE, PADTYPE_MULTITAP },
+  { "PadType10", &padType[9], PADTYPE_NONE, PADTYPE_MULTITAP },
+  { "PadAssign1", &padAssign[0], PADASSIGN_INPUT0, PADASSIGN_INPUT1D },
+  { "PadAssign2", &padAssign[1], PADASSIGN_INPUT0, PADASSIGN_INPUT1D },
+  { "PadAssign3", &padAssign[2], PADASSIGN_INPUT0, PADASSIGN_INPUT1D },
+  { "PadAssign4", &padAssign[3], PADASSIGN_INPUT0, PADASSIGN_INPUT1D },
+  { "PadAssign5", &padAssign[4], PADASSIGN_INPUT0, PADASSIGN_INPUT1D },
+  { "PadAssign6", &padAssign[5], PADASSIGN_INPUT0, PADASSIGN_INPUT1D },
+  { "PadAssign7", &padAssign[6], PADASSIGN_INPUT0, PADASSIGN_INPUT1D },
+  { "PadAssign8", &padAssign[7], PADASSIGN_INPUT0, PADASSIGN_INPUT1D },
+  { "PadAssign9", &padAssign[8], PADASSIGN_INPUT0, PADASSIGN_INPUT1D },
+  { "PadAssign10", &padAssign[9], PADASSIGN_INPUT0, PADASSIGN_INPUT1D },
   { "RumbleEnabled", &rumbleEnabled, RUMBLE_DISABLE, RUMBLE_ENABLE },
   { "LoadButtonSlot", &loadButtonSlot, LOADBUTTON_SLOT0, LOADBUTTON_DEFAULT },
   { "ControllerType", &controllerType, CONTROLLERTYPE_STANDARD, CONTROLLERTYPE_ANALOG },
@@ -195,7 +212,9 @@ static struct {
   { "TrapFilter", &trapFilter, TRAPFILTER_DISABLE, TRAPFILTER_ENABLE },
   { "Interlaced", &interlacedMode, INTERLACED_DISABLE, INTERLACED_ENABLE },
   { "DeflickerFilter", &deflickerFilter, DEFLICKER_DISABLE, DEFLICKER_ENABLE },
-  { "LightGun", &lightGun, LIGHTGUN_DISABLE, LIGHTGUN_JUST }
+  { "LightGun", &lightGun, LIGHTGUN_DISABLE, LIGHTGUN_JUST },
+  { "Memcard0", &memCard[0], MEMCARD_DISABLE, MEMCARD_ENABLE },
+  { "Memcard1", &memCard[1], MEMCARD_DISABLE, MEMCARD_ENABLE }
 };
 void handleConfigPair(char* kv);
 void readConfig(FILE* f);
@@ -227,10 +246,13 @@ void loadSettings(int argc, char *argv[])
 	videoMode		 = VIDEOMODE_AUTO;
 	fileSortMode	 = FILESORT_DIRS_FIRST;
 	padAutoAssign	 = PADAUTOASSIGN_AUTOMATIC;
-	padType[0]		 = PADTYPE_NONE;
-	padType[1]		 = PADTYPE_NONE;
-	padAssign[0]	 = PADASSIGN_INPUT0;
+	for (int i = 0; i < 10; i++){
+		padType[i]		 = PADTYPE_NONE;
+		padAssign[i]	 = PADASSIGN_INPUT0;
+	}
 	padAssign[1]	 = PADASSIGN_INPUT1;
+	memCard[0]		 = MEMCARD_ENABLE;
+	memCard[1]		 = MEMCARD_ENABLE;
 	rumbleEnabled	 = RUMBLE_ENABLE;
 	loadButtonSlot	 = LOADBUTTON_DEFAULT;
 	controllerType	 = CONTROLLERTYPE_STANDARD;

--- a/Gamecube/PadSSSPSX.h
+++ b/Gamecube/PadSSSPSX.h
@@ -31,5 +31,6 @@ typedef struct
 } SSSConfig;
 
 void lightgunInterrupt(void);
+void SSS_SetMultiPad(int pad, int mpad);
 
 #endif

--- a/Gamecube/PadWiiSX.c
+++ b/Gamecube/PadWiiSX.c
@@ -30,7 +30,7 @@
 #include "gc_input/controller.h"
 #include "wiiSXconfig.h"
 
-extern virtualControllers_t virtualControllers[2];
+extern virtualControllers_t virtualControllers[10];
 extern int stop;
 
 // Use to invoke func on the mapped controller with args

--- a/Gamecube/PlugPAD.c
+++ b/Gamecube/PlugPAD.c
@@ -52,7 +52,7 @@ extern int stop;
 //extern char controllerType = 0; // 0 = standard, 1 = analog (analog fails on old games)
 long  PadFlags = 0;
 
-virtualControllers_t virtualControllers[2];
+virtualControllers_t virtualControllers[10];
 
 controller_t* controller_ts[num_controller_t] =
 #if defined(WII) && !defined(NO_BT)
@@ -110,7 +110,7 @@ void assign_controller(int wv, controller_t* type, int wp){
 	virtualControllers[wv].control = type;
 	virtualControllers[wv].inUse   = 1;
 	virtualControllers[wv].number  = wp;
-	virtualControllers[wv].config  = &type->config[wv];
+	virtualControllers[wv].config  = &type->config[wp];
 
 	type->assign(wp,wv);
 }

--- a/Gamecube/gc_input/controller.h
+++ b/Gamecube/gc_input/controller.h
@@ -134,7 +134,7 @@ typedef struct _virtualControllers_t {
 	controller_config_t* config; // This is no longer needed...
 } virtualControllers_t;
 
-extern virtualControllers_t virtualControllers[2];
+extern virtualControllers_t virtualControllers[10];
 
 // List of all the defined controller_t's
 #if defined(WII) && !defined(NO_BT)

--- a/Gamecube/libgui/InputStatusBar.cpp
+++ b/Gamecube/libgui/InputStatusBar.cpp
@@ -76,7 +76,8 @@ void InputStatusBar::drawComponent(Graphics& gfx)
 	int box_x = 50;
 	int box_y = 0;
 	int width = 235;
-	int height = 340;
+	int height = 340 + 65*((padType[0] == PADTYPE_MULTITAP)
+						  +(padType[1] == PADTYPE_MULTITAP));
 	int labelScissor = 5;
 	GXColor activeColor = (GXColor) {255, 255, 255, 255};
 	GXColor inactiveColor = (GXColor) {192, 192, 192, 192};
@@ -86,6 +87,8 @@ void InputStatusBar::drawComponent(Graphics& gfx)
 //									{255, 192,   1, 255}, //yellow/gold
 //									{150, 150, 255, 255}};
 //	char statusText[50];
+	char padNames[10][3] = {"1","2","1A","1B","1C","1D",
+							"2A","2B","2C","2D"};
 	Image* statusIcon = NULL;
 	//Draw Status Info Box
 	GXColor boxColor = (GXColor) {87, 90, 100,128};
@@ -123,8 +126,18 @@ void InputStatusBar::drawComponent(Graphics& gfx)
 	}
 	gfx.disableScissor();
 	//Update controller availability
-	for (int i = 0; i < 2; i++)
+	for (int i = 0; i < 10; i++)
 	{
+		if ((padType[0] != PADTYPE_MULTITAP) && (i == 2)){
+			i+=3;
+			continue;
+		}
+		
+		if ((padType[1] != PADTYPE_MULTITAP) && (i == 6)){
+			i+=3;
+			continue;
+		}
+		
 		switch (padType[i])
 		{
 		case PADTYPE_GAMECUBE:
@@ -212,6 +225,7 @@ void InputStatusBar::drawComponent(Graphics& gfx)
 
 			break;
 #endif
+		case PADTYPE_MULTITAP:
 		case PADTYPE_NONE:
 			gfx.setColor(inactiveColor);
 			IplFont::getInstance().drawInit(inactiveColor);
@@ -223,14 +237,34 @@ void InputStatusBar::drawComponent(Graphics& gfx)
 //		IplFont::getInstance().drawString((int) box_x+width/2, (int) 215+30*i, statusText, 1.0, true);
 		int base_x = box_x + 14 + 53*i;
 		int base_y = 260;
+		if (i > 1 && i < 6){
+			base_y = 330;
+			base_x = box_x + 14 + 53*(i-2);
+		}
+		if (i > 5){
+			if (padType[0]==PADTYPE_MULTITAP)
+				base_y = 395;
+			else 
+				base_y = 330;
+			base_x = box_x + 14 + 53*(i-6);
+		}
+			
 		//draw numbers
-		sprintf(buffer,"%d",i+1);
+		sprintf(buffer,padNames[i]);
 		IplFont::getInstance().drawString((int) base_x+36, (int) base_y+10, buffer, 0.8, true);
-		if (padType[i]!=PADTYPE_NONE)
+		if (padType[i]==PADTYPE_MULTITAP)
+		{
+			sprintf(buffer,"M");
+			IplFont::getInstance().drawString((int) base_x+34, (int) base_y+32, buffer, 0.8, true);
+			sprintf(buffer,"Tap");
+			IplFont::getInstance().drawString((int) base_x+21, (int) base_y+49, buffer, 0.8, true);
+		}
+		else if (padType[i]!=PADTYPE_NONE)
 		{
 			sprintf(buffer,"%d",padAssign[i]+1);
 			IplFont::getInstance().drawString((int) base_x+37, (int) base_y+52, buffer, 0.8, true);
 		}
+		
 		//draw icon
 		statusIcon->activateImage(GX_TEXMAP0);
 		GX_SetTevColorIn(GX_TEVSTAGE0,GX_CC_ZERO,GX_CC_ZERO,GX_CC_ZERO,GX_CC_RASC);

--- a/Gamecube/menu/ConfigureButtonsFrame.cpp
+++ b/Gamecube/menu/ConfigureButtonsFrame.cpp
@@ -229,6 +229,9 @@ static char controllerTypeStrings[7][17] =
 	  "Wii U Pro",
 	  "Wii U Gamepad",
 	  "NULL"};
+	  
+static char padNames[10][3] = {"1","2","1A","1B","1C","1D",
+							"2A","2B","2C","2D"};
 
 enum ActivePadType
 {
@@ -310,7 +313,7 @@ void ConfigureButtonsFrame::activateSubmenu(int submenu)
 	}
 	else
 	{
-		sprintf(TITLE_STRING, "PSX Pad %d: %s Pad %d Mapping", activePad+1, controllerTypeStrings[activePadType], virtualControllers[activePad].number+1 );
+		sprintf(TITLE_STRING, "PSX Pad %s: %s Pad %d Mapping", padNames[activePad], controllerTypeStrings[activePadType], virtualControllers[activePad].number+1 );
 	
 		controller_config_t* currentConfig = virtualControllers[activePad].config;
 
@@ -488,7 +491,13 @@ extern MenuContext *pMenuContext;
 
 void Func_NextPad()
 {
-	activePad = (activePad+1) %2;
+	activePad = (activePad+1) %10;
+	
+	if (activePad == 2 && padType[0]!=PADTYPE_MULTITAP)
+		activePad += 4;
+	if (activePad == 6 && padType[1]!=PADTYPE_MULTITAP)
+		activePad = 0;
+	
 
 	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREBUTTONS)->activateSubmenu(activePad);
 }

--- a/Gamecube/menu/ConfigureInputFrame.cpp
+++ b/Gamecube/menu/ConfigureInputFrame.cpp
@@ -39,30 +39,48 @@ void Func_ManualSelectInput();
 
 void Func_TogglePad0Type();
 void Func_TogglePad1Type();
+void Func_TogglePad0AType();
+void Func_TogglePad0BType();
+void Func_TogglePad0CType();
+void Func_TogglePad0DType();
+void Func_TogglePad1AType();
+void Func_TogglePad1BType();
+void Func_TogglePad1CType();
+void Func_TogglePad1DType();
+
 void Func_TogglePad0Assign();
 void Func_TogglePad1Assign();
+void Func_TogglePad0AAssign();
+void Func_TogglePad0BAssign();
+void Func_TogglePad0CAssign();
+void Func_TogglePad0DAssign();
+void Func_TogglePad1AAssign();
+void Func_TogglePad1BAssign();
+void Func_TogglePad1CAssign();
+void Func_TogglePad1DAssign();
 
 void Func_ReturnFromConfigureInputFrame();
 
 
-#define NUM_FRAME_BUTTONS 6
+#define NUM_FRAME_BUTTONS 22
 #define FRAME_BUTTONS configureInputFrameButtons
 #define FRAME_STRINGS configureInputFrameStrings
-#define NUM_FRAME_TEXTBOXES 3
+#define NUM_FRAME_TEXTBOXES 5
 #define FRAME_TEXTBOXES configureInputFrameTextBoxes
 
-static char FRAME_STRINGS[16][15] =
+static char FRAME_STRINGS[17][15] =
 	{ "Pad Assignment",
 	  "PSX Pad 1",
 	  "PSX Pad 2",
-	  "PSX Pad 3",
-	  "PSX Pad 4",
+	  "Multitap 1",
+	  "Multitap 2",
 
 	  "Automatic",
 	  "Manual",
 	  "None",
 	  "Gamecube Pad",
 	  "Wii Pad",
+	  "Multitap",
 	  "Auto Assign",
 	  "",
 	  "1",
@@ -87,13 +105,28 @@ struct ButtonInfo
 	ButtonFunc		returnFunc;
 } FRAME_BUTTONS[NUM_FRAME_BUTTONS] =
 { //	button	buttonStyle buttonString		x		y		width	height	Up	Dwn	Lft	Rt	clickFunc				returnFunc
-	{	NULL,	BTN_A_SEL,	FRAME_STRINGS[5],	240.0,	 80.0,	135.0,	56.0,	 5,	 2,	 1,	 1,	Func_AutoSelectInput,	Func_ReturnFromConfigureInputFrame }, // Automatic Pad Assignment
-	{	NULL,	BTN_A_SEL,	FRAME_STRINGS[6],	395.0,	 80.0,	120.0,	56.0,	 9,	 6,	 0,	 0,	Func_ManualSelectInput,	Func_ReturnFromConfigureInputFrame }, // Manual Pad Assignment
-	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[10],	240.0,	150.0,	200.0,	56.0,	 0,	 3,	 4,	 4,	Func_TogglePad0Type,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 0 Type
-	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[10],	240.0,	220.0,	200.0,	56.0,	 2,	 0,	 5,	 5,	Func_TogglePad1Type,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 1 Type
-	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[11],	460.0,	150.0,	 55.0,	56.0,	 1,	 5,	 2,	 2,	Func_TogglePad0Assign,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 0 Assignment
-	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[11],	460.0,	220.0,	 55.0,	56.0,	 4,	 1,	 3,	 3,	Func_TogglePad1Assign,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 1 Assignment
-
+	{	NULL,	BTN_A_SEL,	FRAME_STRINGS[5],	240.0,	 30.0,	135.0,	56.0,	 17, 2,	 1,	 1,	Func_AutoSelectInput,	Func_ReturnFromConfigureInputFrame }, // Automatic Pad Assignment
+	{	NULL,	BTN_A_SEL,	FRAME_STRINGS[6],	395.0,	 30.0,	120.0,	56.0,	 21, 3,	 0,	 0,	Func_ManualSelectInput,	Func_ReturnFromConfigureInputFrame }, // Manual Pad Assignment
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[11],	30.0,	135.0,	200.0,	56.0,	 0,	 4,	 13, 12,Func_TogglePad0Type,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 0 Type
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[11],	330.0,	135.0,	200.0,	56.0,	 1,	 8,	 12, 13,Func_TogglePad1Type,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 1 Type
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[11],	30.0,	250.0,	200.0,	56.0,	 3,	 5,	 18, 14,Func_TogglePad0AType,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 0A Type
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[11],	30.0,	306.0,	200.0,	56.0,	 4,	 6,	 19, 15,Func_TogglePad0BType,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 0B Type
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[11],	30.0,	362.0,	200.0,	56.0,	 5,	 7,	 20, 16,Func_TogglePad0CType,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 0C Type
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[11],	30.0,	418.0,	200.0,	56.0,	 6,	 0,	 21, 17,Func_TogglePad0DType,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 0D Type
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[11],	330.0,	250.0,	200.0,	56.0,	 3,	 9,	 14, 18,Func_TogglePad1AType,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 1A Type
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[11],	330.0,	306.0,	200.0,	56.0,	 8,	 10, 15, 19,Func_TogglePad1BType,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 1B Type
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[11],	330.0,	362.0,	200.0,	56.0,	 9,	 11, 16, 20,Func_TogglePad1CType,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 1C Type
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[11],	330.0,	418.0,	200.0,	56.0,	 10, 1,	 17, 21,Func_TogglePad1DType,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 1D Type
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[12],	250.0,	135.0,	 55.0,	56.0,	 0,	 14, 2,	 3,	Func_TogglePad0Assign,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 0 Assignment
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[12],	550.0,	135.0,	 55.0,	56.0,	 1,	 18, 3,	 2,	Func_TogglePad1Assign,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 1 Assignment
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[12],	250.0,	250.0,	 55.0,	56.0,	 12, 15, 4,	 8,	Func_TogglePad0AAssign,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 0A Assignment
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[12],	250.0,	306.0,	 55.0,	56.0,	 14, 16, 5,	 9,	Func_TogglePad0BAssign,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 0B Assignment
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[12],	250.0,	362.0,	 55.0,	56.0,	 15, 17, 6,	 10,Func_TogglePad0CAssign,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 0C Assignment
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[12],	250.0,	418.0,	 55.0,	56.0,	 16, 0,	 7,	 11,Func_TogglePad0DAssign,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 0D Assignment
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[12],	550.0,	250.0,	 55.0,	56.0,	 13, 19, 8,	 4,	Func_TogglePad1AAssign,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 1A Assignment
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[12],	550.0,	306.0,	 55.0,	56.0,	 18, 20, 9,	 5,	Func_TogglePad1BAssign,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 1B Assignment
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[12],	550.0,	362.0,	 55.0,	56.0,	 19, 21, 10, 6,	Func_TogglePad1CAssign,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 1C Assignment
+	{	NULL,	BTN_A_NRM,	FRAME_STRINGS[12],	550.0,	418.0,	 55.0,	56.0,	 20, 1,	 11, 7,	Func_TogglePad1DAssign,	Func_ReturnFromConfigureInputFrame }, // Toggle Pad 1D Assignment
 };
 
 struct TextBoxInfo
@@ -106,9 +139,11 @@ struct TextBoxInfo
 	bool			centered;
 } FRAME_TEXTBOXES[NUM_FRAME_TEXTBOXES] =
 { //	textBox	textBoxString		x		y		scale	centered
-	{	NULL,	FRAME_STRINGS[0],	125.0,	108.0,	 1.0,	true }, // Pad Assignment
-	{	NULL,	FRAME_STRINGS[1],	125.0,	178.0,	 1.0,	true }, // Pad 1
-	{	NULL,	FRAME_STRINGS[2],	125.0,	248.0,	 1.0,	true }, // Pad 2
+	{	NULL,	FRAME_STRINGS[0],	125.0,	68.0,	 1.0,	true }, // Pad Assignment
+	{	NULL,	FRAME_STRINGS[1],	125.0,	115.0,	 1.0,	true }, // Pad 1
+	{	NULL,	FRAME_STRINGS[2],	425.0,	115.0,	 1.0,	true }, // Pad 2
+	{	NULL,	FRAME_STRINGS[3],	125.0,	228.0,	 1.0,	true }, // Multitap 1
+	{	NULL,	FRAME_STRINGS[4],	425.0,	228.0,	 1.0,	true }, // Multitap 2
 };
 
 ConfigureInputFrame::ConfigureInputFrame()
@@ -169,29 +204,53 @@ void ConfigureInputFrame::activateSubmenu(int submenu)
 		FRAME_BUTTONS[0].button->setNextFocus(menu::Focus::DIRECTION_UP, NULL);
 		FRAME_BUTTONS[1].button->setNextFocus(menu::Focus::DIRECTION_DOWN, NULL);
 		FRAME_BUTTONS[1].button->setNextFocus(menu::Focus::DIRECTION_UP, NULL);
-		for (int i = 0; i < 2; i++)
+		for (int i = 0; i < 10; i++)
 		{
 			FRAME_BUTTONS[i+2].button->setActive(false);
-			FRAME_BUTTONS[i+2].buttonString = FRAME_STRINGS[10];
-			FRAME_BUTTONS[i+4].button->setActive(false);
-			FRAME_BUTTONS[i+4].buttonString = FRAME_STRINGS[11];
+			FRAME_BUTTONS[i+2].buttonString = FRAME_STRINGS[11];
+			if (i>1)	FRAME_BUTTONS[i+2].buttonString = FRAME_STRINGS[12];
+			FRAME_BUTTONS[i+12].button->setActive(false);
+			FRAME_BUTTONS[i+12].buttonString = FRAME_STRINGS[12];
 		}
 	}
 	else
 	{
 		FRAME_BUTTONS[0].button->setSelected(false);
 		FRAME_BUTTONS[1].button->setSelected(true);
-		FRAME_BUTTONS[0].button->setNextFocus(menu::Focus::DIRECTION_DOWN, FRAME_BUTTONS[2].button);
-		FRAME_BUTTONS[0].button->setNextFocus(menu::Focus::DIRECTION_UP, FRAME_BUTTONS[3].button);
-		FRAME_BUTTONS[1].button->setNextFocus(menu::Focus::DIRECTION_DOWN, FRAME_BUTTONS[4].button);
-		FRAME_BUTTONS[1].button->setNextFocus(menu::Focus::DIRECTION_UP, FRAME_BUTTONS[5].button);
-		for (int i = 0; i < 2; i++)
+		for (int i = 0; i < NUM_FRAME_BUTTONS; i++)
+		{
+			if (FRAME_BUTTONS[i].focusUp != -1) FRAME_BUTTONS[i].button->setNextFocus(menu::Focus::DIRECTION_UP, FRAME_BUTTONS[FRAME_BUTTONS[i].focusUp].button);
+			if (FRAME_BUTTONS[i].focusDown != -1) FRAME_BUTTONS[i].button->setNextFocus(menu::Focus::DIRECTION_DOWN, FRAME_BUTTONS[FRAME_BUTTONS[i].focusDown].button);
+			if (FRAME_BUTTONS[i].focusLeft != -1) FRAME_BUTTONS[i].button->setNextFocus(menu::Focus::DIRECTION_LEFT, FRAME_BUTTONS[FRAME_BUTTONS[i].focusLeft].button);
+			if (FRAME_BUTTONS[i].focusRight != -1) FRAME_BUTTONS[i].button->setNextFocus(menu::Focus::DIRECTION_RIGHT, FRAME_BUTTONS[FRAME_BUTTONS[i].focusRight].button);
+		}
+		for (int i = 0; i < 10; i++)
 		{
 			FRAME_BUTTONS[i+2].button->setActive(true);
 			FRAME_BUTTONS[i+2].buttonString = FRAME_STRINGS[padType[i]+7];
-			FRAME_BUTTONS[i+4].button->setActive(true);
-			FRAME_BUTTONS[i+4].buttonString = FRAME_STRINGS[padAssign[i]+12];
+			FRAME_BUTTONS[i+12].button->setActive(true);
+			FRAME_BUTTONS[i+12].buttonString = FRAME_STRINGS[padAssign[i]+13];
 		}
+		
+		
+	}
+	
+	if (padType[0] != PADTYPE_MULTITAP){
+		for (int i = 2; i < 6; i++){
+			FRAME_BUTTONS[i+2].button->setActive(false);
+			FRAME_BUTTONS[i+2].buttonString = FRAME_STRINGS[12];
+			FRAME_BUTTONS[i+12].button->setActive(false);
+			FRAME_BUTTONS[i+12].buttonString = FRAME_STRINGS[12];
+		}
+	}
+	if (padType[1] != PADTYPE_MULTITAP){
+		for (int i = 6; i < 10; i++){
+			FRAME_BUTTONS[i+2].button->setActive(false);
+			FRAME_BUTTONS[i+2].buttonString = FRAME_STRINGS[12];
+			FRAME_BUTTONS[i+12].button->setActive(false);
+			FRAME_BUTTONS[i+12].buttonString = FRAME_STRINGS[12];
+		}
+			
 	}
 }
 
@@ -230,34 +289,48 @@ void Func_AssignPad(int i)
 			type = &controller_WiimoteNunchuk;
 		break;
 #endif
+	case PADTYPE_NONE:
+		unassign_controller(i);
+		return;
 	}
-	assign_controller(i, type, (int) padAssign[i]);
+		assign_controller(i, type, (int) padAssign[i]);
 }
 
 void Func_TogglePad0Type()
 {
 	int i = PADASSIGN_INPUT0;
 #ifdef HW_RVL
-	padType[i] = (padType[i]+1) %3;
+	padType[i] = (padType[i]+1) %4;
 #else
-	padType[i] = (padType[i]+1) %2;
+	padType[i] = (padType[i]+1) %3;
 #endif
 
-	if (padType[i]) Func_AssignPad(i);
+	if (padType[i] == PADTYPE_MULTITAP){ 
+		unassign_controller(i);
+		for(int j = 2;  j < 6; j++)
+			Func_AssignPad(j);
+	}
+	else if (padType[i]) Func_AssignPad(i);
 	else			unassign_controller(i);
 	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREINPUT)->activateSubmenu(ConfigureInputFrame::SUBMENU_REINIT);
 }
+
 
 void Func_TogglePad1Type()
 {
 	int i = PADASSIGN_INPUT1;
 #ifdef HW_RVL
-	padType[i] = (padType[i]+1) %3;
+	padType[i] = (padType[i]+1) %4;
 #else
-	padType[i] = (padType[i]+1) %2;
+	padType[i] = (padType[i]+1) %3;
 #endif
-
-	if (padType[i]) Func_AssignPad(i);
+	
+	if (padType[i] == PADTYPE_MULTITAP){ 
+		unassign_controller(i);
+		for(int j = 6;  j < 10; j++)
+			Func_AssignPad(j);
+	}
+	else if (padType[i]) Func_AssignPad(i);
 	else			unassign_controller(i);
 	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREINPUT)->activateSubmenu(ConfigureInputFrame::SUBMENU_REINIT);
 }
@@ -267,7 +340,7 @@ void Func_TogglePad0Assign()
 	int i = PADASSIGN_INPUT0;
 	padAssign[i] = (padAssign[i]+1) %4;
 
-	if (padType[i]) Func_AssignPad(i);
+	if (padType[i] && padType[i] != PADTYPE_MULTITAP) Func_AssignPad(i);
 
 	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREINPUT)->activateSubmenu(ConfigureInputFrame::SUBMENU_REINIT);
 }
@@ -277,7 +350,7 @@ void Func_TogglePad1Assign()
 	int i = PADASSIGN_INPUT1;
 	padAssign[i] = (padAssign[i]+1) %4;
 
-	if (padType[i]) Func_AssignPad(i);
+	if (padType[i] && padType[i] != PADTYPE_MULTITAP) Func_AssignPad(i);
 
 	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREINPUT)->activateSubmenu(ConfigureInputFrame::SUBMENU_REINIT);
 }
@@ -286,3 +359,208 @@ void Func_ReturnFromConfigureInputFrame()
 {
 	pMenuContext->setActiveFrame(MenuContext::FRAME_SETTINGS,SettingsFrame::SUBMENU_INPUT);
 }
+
+
+//////////////////////////////////
+//		Multitap functions		//
+//////////////////////////////////
+
+void Func_TogglePad0AType()
+{
+	int i = PADASSIGN_INPUT0A;
+#ifdef HW_RVL
+	padType[i] = (padType[i]+1) %3;
+#else
+	padType[i] = (padType[i]+1) %2;
+#endif
+
+	if (padType[i]) Func_AssignPad(i);
+	else			unassign_controller(i);
+	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREINPUT)->activateSubmenu(ConfigureInputFrame::SUBMENU_REINIT);
+}
+
+void Func_TogglePad0BType()
+{
+	int i = PADASSIGN_INPUT0B;
+#ifdef HW_RVL
+	padType[i] = (padType[i]+1) %3;
+#else
+	padType[i] = (padType[i]+1) %2;
+#endif
+
+	if (padType[i]) Func_AssignPad(i);
+	else			unassign_controller(i);
+	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREINPUT)->activateSubmenu(ConfigureInputFrame::SUBMENU_REINIT);
+}
+
+void Func_TogglePad0CType()
+{
+	int i = PADASSIGN_INPUT0C;
+#ifdef HW_RVL
+	padType[i] = (padType[i]+1) %3;
+#else
+	padType[i] = (padType[i]+1) %2;
+#endif
+
+	if (padType[i]) Func_AssignPad(i);
+	else			unassign_controller(i);
+	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREINPUT)->activateSubmenu(ConfigureInputFrame::SUBMENU_REINIT);
+}
+
+void Func_TogglePad0DType()
+{
+	int i = PADASSIGN_INPUT0D;
+#ifdef HW_RVL
+	padType[i] = (padType[i]+1) %3;
+#else
+	padType[i] = (padType[i]+1) %2;
+#endif
+
+	if (padType[i]) Func_AssignPad(i);
+	else			unassign_controller(i);
+	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREINPUT)->activateSubmenu(ConfigureInputFrame::SUBMENU_REINIT);
+}
+
+///////////////////////////////////////////// Second Pad Type
+
+void Func_TogglePad1AType()
+{
+	int i = PADASSIGN_INPUT1A;
+#ifdef HW_RVL
+	padType[i] = (padType[i]+1) %3;
+#else
+	padType[i] = (padType[i]+1) %2;
+#endif
+
+	if (padType[i]) Func_AssignPad(i);
+	else			unassign_controller(i);
+	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREINPUT)->activateSubmenu(ConfigureInputFrame::SUBMENU_REINIT);
+}
+
+void Func_TogglePad1BType()
+{
+	int i = PADASSIGN_INPUT1B;
+#ifdef HW_RVL
+	padType[i] = (padType[i]+1) %3;
+#else
+	padType[i] = (padType[i]+1) %2;
+#endif
+
+	if (padType[i]) Func_AssignPad(i);
+	else			unassign_controller(i);
+	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREINPUT)->activateSubmenu(ConfigureInputFrame::SUBMENU_REINIT);
+}
+
+void Func_TogglePad1CType()
+{
+	int i = PADASSIGN_INPUT1C;
+#ifdef HW_RVL
+	padType[i] = (padType[i]+1) %3;
+#else
+	padType[i] = (padType[i]+1) %2;
+#endif
+
+	if (padType[i]) Func_AssignPad(i);
+	else			unassign_controller(i);
+	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREINPUT)->activateSubmenu(ConfigureInputFrame::SUBMENU_REINIT);
+}
+
+void Func_TogglePad1DType()
+{
+	int i = PADASSIGN_INPUT1D;
+#ifdef HW_RVL
+	padType[i] = (padType[i]+1) %3;
+#else
+	padType[i] = (padType[i]+1) %2;
+#endif
+
+	if (padType[i]) Func_AssignPad(i);
+	else			unassign_controller(i);
+	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREINPUT)->activateSubmenu(ConfigureInputFrame::SUBMENU_REINIT);
+}
+
+
+///////////////////////////////////////////// Assign
+
+void Func_TogglePad0AAssign()
+{
+	int i = PADASSIGN_INPUT0A;
+	padAssign[i] = (padAssign[i]+1) %4;
+
+	if (padType[i]) Func_AssignPad(i);
+
+	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREINPUT)->activateSubmenu(ConfigureInputFrame::SUBMENU_REINIT);
+}
+
+void Func_TogglePad0BAssign()
+{
+	int i = PADASSIGN_INPUT0B;
+	padAssign[i] = (padAssign[i]+1) %4;
+
+	if (padType[i]) Func_AssignPad(i);
+
+	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREINPUT)->activateSubmenu(ConfigureInputFrame::SUBMENU_REINIT);
+}
+
+void Func_TogglePad0CAssign()
+{
+	int i = PADASSIGN_INPUT0C;
+	padAssign[i] = (padAssign[i]+1) %4;
+
+	if (padType[i]) Func_AssignPad(i);
+
+	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREINPUT)->activateSubmenu(ConfigureInputFrame::SUBMENU_REINIT);
+}
+
+void Func_TogglePad0DAssign()
+{
+	int i = PADASSIGN_INPUT0D;
+	padAssign[i] = (padAssign[i]+1) %4;
+
+	if (padType[i]) Func_AssignPad(i);
+
+	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREINPUT)->activateSubmenu(ConfigureInputFrame::SUBMENU_REINIT);
+}
+
+///////////////////////////////////////////// Second Pad Assign
+
+void Func_TogglePad1AAssign()
+{
+	int i = PADASSIGN_INPUT1A;
+	padAssign[i] = (padAssign[i]+1) %4;
+
+	if (padType[i]) Func_AssignPad(i);
+
+	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREINPUT)->activateSubmenu(ConfigureInputFrame::SUBMENU_REINIT);
+}
+
+void Func_TogglePad1BAssign()
+{
+	int i = PADASSIGN_INPUT1B;
+	padAssign[i] = (padAssign[i]+1) %4;
+
+	if (padType[i]) Func_AssignPad(i);
+
+	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREINPUT)->activateSubmenu(ConfigureInputFrame::SUBMENU_REINIT);
+}
+
+void Func_TogglePad1CAssign()
+{
+	int i = PADASSIGN_INPUT1C;
+	padAssign[i] = (padAssign[i]+1) %4;
+
+	if (padType[i]) Func_AssignPad(i);
+
+	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREINPUT)->activateSubmenu(ConfigureInputFrame::SUBMENU_REINIT);
+}
+
+void Func_TogglePad1DAssign()
+{
+	int i = PADASSIGN_INPUT1D;
+	padAssign[i] = (padAssign[i]+1) %4;
+
+	if (padType[i]) Func_AssignPad(i);
+
+	pMenuContext->getFrame(MenuContext::FRAME_CONFIGUREINPUT)->activateSubmenu(ConfigureInputFrame::SUBMENU_REINIT);
+}
+

--- a/Gamecube/menu/FileBrowserFrame.cpp
+++ b/Gamecube/menu/FileBrowserFrame.cpp
@@ -435,7 +435,7 @@ void fileBrowserFrame_FillPage()
 			FRAME_BUTTONS[i+2].button->setClicked(FRAME_BUTTONS[i+2].clickedFunc);
 			FRAME_BUTTONS[i+2].button->setActive(true);
 			if(dir_entries[i+(current_page*NUM_FILE_SLOTS)].attr & FILE_BROWSER_ATTR_DIR)
-				FRAME_BUTTONS[i+2].button->setLabelColor((GXColor) {255,50,50,255});
+				FRAME_BUTTONS[i+2].button->setLabelColor((GXColor) {254,213,95,255});
 		}
 		else
 			FRAME_BUTTONS[i+2].buttonString = FRAME_STRINGS[2];

--- a/Gamecube/menu/SettingsFrame.cpp
+++ b/Gamecube/menu/SettingsFrame.cpp
@@ -110,6 +110,9 @@ void Func_AutoSaveYes();
 void Func_AutoSaveNo();
 void Func_SaveStateSD();
 void Func_SaveStateUSB();
+void Func_Memcard1();
+void Func_Memcard2();
+
 
 void Func_FastloadYes();
 void Func_FastloadNo();
@@ -133,11 +136,11 @@ void pauseAudio(void);  void pauseInput(void);
 void resumeAudio(void); void resumeInput(void);
 }
 
-#define NUM_FRAME_BUTTONS 60
+#define NUM_FRAME_BUTTONS 62
 #define NUM_TAB_BUTTONS 5
 #define FRAME_BUTTONS settingsFrameButtons
 #define FRAME_STRINGS settingsFrameStrings
-#define NUM_FRAME_TEXTBOXES 23
+#define NUM_FRAME_TEXTBOXES 24
 #define FRAME_TEXTBOXES settingsFrameTextBoxes
 
 /*
@@ -175,7 +178,7 @@ Auto Save Memcards: Yes; No
 Save States Device: SD; USB
 */
 
-static char FRAME_STRINGS[73][24] =
+static char FRAME_STRINGS[76][24] =
 	{ "General",
 	  "Video",
 	  "Input",
@@ -255,7 +258,10 @@ static char FRAME_STRINGS[73][24] =
 	  "Lightrec",
 	  "Lightgun ",
 	  "GunCon",
-	  "Justifier "
+	  "Justifier ",
+	  "Memcard 1",
+	  "Memcard 2",
+	  "Enable Memcard"
       };
 
 
@@ -343,7 +349,9 @@ struct ButtonInfo
 	{	NULL,	BTN_A_SEL,	FRAME_STRINGS[17],	570.0,	310.0,	 75.0,	56.0,	13,	15,	55,	54,	Func_FastloadNo,		Func_ReturnFromSettingsFrame }, // Fast load: No
 	{	NULL,	BTN_A_SEL,	FRAME_STRINGS[64],	510.0,	280.0,	 75.0,	56.0,	21,	27,	23,	22,	Func_Screen240p,		Func_ReturnFromSettingsFrame },  // ScreenMode: 240p
 	{	NULL,	BTN_A_SEL,	FRAME_STRINGS[11],	505.0,	100.0,	130.0,	56.0,	 0,	 9,	 6,	 5,	Func_CpuDynarec,		Func_ReturnFromSettingsFrame },  // CPU: Dynarec
-	{	NULL,	BTN_A_SEL,	FRAME_STRINGS[70],	510.0,	170.0,	115.0,	56.0,	31,	35,	33,	32,	Func_PsxTypeLightgun,	Func_ReturnFromSettingsFrame }  // PSX Controller Type: Lightgun
+	{	NULL,	BTN_A_SEL,	FRAME_STRINGS[70],	510.0,	170.0,	115.0,	56.0,	31,	35,	33,	32,	Func_PsxTypeLightgun,	Func_ReturnFromSettingsFrame },  // PSX Controller Type: Lightgun
+	{	NULL,	BTN_A_SEL,	FRAME_STRINGS[73],	295.0,	310.0,	155.0,	56.0,	31,	35,	33,	32,	Func_Memcard1,			Func_ReturnFromSettingsFrame },  // Memcard 1 toggle
+	{	NULL,	BTN_A_SEL,	FRAME_STRINGS[74],	460.0,	310.0,	155.0,	56.0,	31,	35,	33,	32,	Func_Memcard2,			Func_ReturnFromSettingsFrame }  // Memcard 2 toggle
 };
 
 struct TextBoxInfo
@@ -384,6 +392,7 @@ struct TextBoxInfo
 	{	NULL,	FRAME_STRINGS[53],	150.0,	268.0,	 1.0,	true }, // Save State Device: SD/USB
 	{	NULL,	FRAME_STRINGS[56],	130.0,	338.0,	 1.0,	true }, // Select language: En, Chs, ......
 	{	NULL,	FRAME_STRINGS[63],	405.0,	338.0,	 1.0,	true }, // Fast load
+	{	NULL,	FRAME_STRINGS[75],	150.0,	338.0,	 1.0,	true }, // Memcard enable
 };
 
 SettingsFrame::SettingsFrame()
@@ -613,12 +622,19 @@ void SettingsFrame::activateSubmenu(int submenu)
 			}
 			for (int i = 18; i < 21; i++)
 				FRAME_TEXTBOXES[i].textBox->setVisible(true);
+			FRAME_TEXTBOXES[23].textBox->setVisible(true);
 			FRAME_BUTTONS[4].button->setSelected(true);
 			FRAME_BUTTONS[46+nativeSaveDevice].button->setSelected(true);
 			if (autoSave == AUTOSAVE_ENABLE)	FRAME_BUTTONS[50].button->setSelected(true);
 			else								FRAME_BUTTONS[51].button->setSelected(true);
 			if (saveStateDevice == SAVESTATEDEVICE_SD)	FRAME_BUTTONS[52].button->setSelected(true);
 			else										FRAME_BUTTONS[53].button->setSelected(true);
+			if (memCard[0] == MEMCARD_ENABLE)FRAME_BUTTONS[60].button->setSelected(true);
+			if (memCard[1] == MEMCARD_ENABLE)FRAME_BUTTONS[61].button->setSelected(true);
+			FRAME_BUTTONS[60].button->setVisible(true);
+			FRAME_BUTTONS[60].button->setActive(true);
+			FRAME_BUTTONS[61].button->setVisible(true);
+			FRAME_BUTTONS[61].button->setActive(true);
 			for (int i = 46; i < NUM_FRAME_BUTTONS; i++)
 			{
 			    if (i >= 54) {
@@ -1302,6 +1318,36 @@ void Func_DisableRumbleNo()
 	FRAME_BUTTONS[35].button->setSelected(true);
 	rumbleEnabled = RUMBLE_ENABLE;
 }
+
+void Func_Memcard1()
+{
+	if(memCard[0] == MEMCARD_ENABLE)
+	{
+		FRAME_BUTTONS[60].button->setSelected(false);
+		memCard[0] = MEMCARD_DISABLE;
+	}
+	else
+	{
+		FRAME_BUTTONS[60].button->setSelected(true);
+		memCard[0] = MEMCARD_ENABLE;
+	}
+}
+
+void Func_Memcard2()
+{
+	if(memCard[1] == MEMCARD_ENABLE)
+	{
+		FRAME_BUTTONS[61].button->setSelected(false);
+		memCard[1] = MEMCARD_DISABLE;
+	}
+	else
+	{
+		FRAME_BUTTONS[61].button->setSelected(true);
+		memCard[1] = MEMCARD_ENABLE;
+	}
+}
+
+
 
 void Func_SaveButtonsSD()
 {

--- a/Gamecube/wiiSXconfig.h
+++ b/Gamecube/wiiSXconfig.h
@@ -181,21 +181,29 @@ enum padAutoAssign
 	PADAUTOASSIGN_AUTOMATIC
 };
 
-extern char padType[2];
+extern char padType[10];
 enum padType
 {
 	PADTYPE_NONE=0,
 	PADTYPE_GAMECUBE,
-	PADTYPE_WII
+	PADTYPE_WII,
+	PADTYPE_MULTITAP
+	
 };
 
-extern char padAssign[2];
+extern char padAssign[10];
 enum padAssign
 {
 	PADASSIGN_INPUT0=0,
 	PADASSIGN_INPUT1,
-	PADASSIGN_INPUT2,
-	PADASSIGN_INPUT3
+	PADASSIGN_INPUT0A,
+	PADASSIGN_INPUT0B,
+	PADASSIGN_INPUT0C,
+	PADASSIGN_INPUT0D,
+	PADASSIGN_INPUT1A,
+	PADASSIGN_INPUT1B,
+	PADASSIGN_INPUT1C,
+	PADASSIGN_INPUT1D,
 };
 
 extern char rumbleEnabled;
@@ -289,6 +297,14 @@ enum lightGun
 	LIGHTGUN_GUNCON,
 	LIGHTGUN_JUST,
 };
+
+extern char memCard[2];
+enum memCard
+{
+	MEMCARD_DISABLE=0,
+	MEMCARD_ENABLE,
+};
+
 
 extern const unsigned char En_dat[];
 extern const unsigned int  En_dat_size;


### PR DESCRIPTION
Added some PS1 Multitap support (up to 8 players). Tested and working Crash Team Racing, Frogger, Bomberman: Party Edition, S.C.A.R.S, and FIFA. Some games like Twisted Metal 3/4 don't work yet.

Keep in mind that some games need the Multitap to be in a specific port, and the standard/analog setting may also be relevant.
PS1 Memory Card (MemCard) enable/disable function (options) allows the game Codename: Tenka to work.

Many thanks to @Jokippo for this.