### PR TITLE
Revert "unbreak some old savestates (notaz)"

### DIFF
--- a/dfsound/freeze.c
+++ b/dfsound/freeze.c
@@ -308,8 +308,8 @@ long CALLBACK DF_SPUfreeze(unsigned long ulFreezeMode, SPUFreeze_t * pF,
  load_register(H_CDLeft, cycles);
  load_register(H_CDRight, cycles);
 
- if (spu.rvb->CurrAddr < spu.rvb->StartAddr)
-  spu.rvb->CurrAddr = spu.rvb->StartAddr;
+ /*if (spu.rvb->CurrAddr < spu.rvb->StartAddr)
+  spu.rvb->CurrAddr = spu.rvb->StartAddr;*/
  // fix to prevent new interpolations from crashing
  for(i=0;i<MAXCHAN;i++) spu.SB[i * SB_SIZE + 28]=0;
 

--- a/psxcounters.c
+++ b/psxcounters.c
@@ -609,9 +609,11 @@ s32 psxRcntFreeze( gzFile f, s32 Mode )
         {
             _psxRcntWmode( i, rcnts[i].mode );
             count = (psxRegs.cycle - rcnts[i].cycleStart) / rcnts[i].rate;
-            //_psxRcntWcount( i, count );
+            _psxRcntWcount( i, count );
+	    /*
             if (count > 0x1000)
                 _psxRcntWcount( i, count & 0xffff );
+	    */
         }
         scheduleRcntBase();
         psxRcntSet();


### PR DESCRIPTION
This reverts commit 0a798fa354f8cdfc912c2adecee2a3212940b939.

This commit broke some savestates made in WiiStation, so by now we're not using this.